### PR TITLE
[✨ Feature/30]: 타이틀 컴포넌트 구현

### DIFF
--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,13 +1,6 @@
 import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
-
-interface TitleProps {
-  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  children: React.ReactNode;
-  className?: string;
-  size?: '3xl' | '2xl' | 'xl' | '2lg' | 'lg' | 'md' | 'sm' | 'xs';
-  weight?: 'bold' | 'semibold' | 'medium' | 'regular';
-}
 
 const titleVariants = cva('text-gray-700', {
   variants: {
@@ -33,6 +26,12 @@ const titleVariants = cva('text-gray-700', {
     weight: 'regular',
   },
 });
+
+interface TitleProps extends VariantProps<typeof titleVariants> {
+  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  children: React.ReactNode;
+  className?: string;
+}
 
 /**
  * Title 컴포넌트


### PR DESCRIPTION

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호
- close #30 

## ✨ 작업한 내용
- Tailwind 기반 공통 `Title` 컴포넌트 추가
- h2~h6 태그 선택 가능
- size, weight, color prop으로 유동적 스타일링 가능

<TEST>
<img width="269" height="284" alt="스크린샷 2025-11-19 22 53 17" src="https://github.com/user-attachments/assets/241e37e0-a714-4703-a367-1583b4870464" />


## 💁 리뷰 요청 / 코멘트

- Tailwind @utility 클래스 매핑(`font-${size}-${weight}`)이 올바르게 적용되는지 확인 부탁드립니다.
- `as` prop으로 h2~h6 태그 변경이 정상 동작하는지도 확인 부탁드립니다.

## 💡 참고사항
- 예시 사용법:
```tsx
<Title as="h2" size="3xl" weight="bold">
  기본 회색 타이틀
</Title>

<Title as="h3" size="2xl" weight="medium" color="--color-violet-500">
  보라색 타이틀
</Title>
