### PR TITLE
[✨ Feature/41] AvatarFallback 컴포넌트 구현

### DIFF
--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import AvatarFallback from '@/components/common/AvatarFallback';
 
 interface AvatarProps {
   profileImgUrl: string | null;
@@ -21,10 +22,8 @@ export default function Avatar({ profileImgUrl, userName, userId, size }: Avatar
           alt={`${userName}님의 프로필`}
         />
       ) : (
-        <div>AvatarFallback{userId}</div>
+        <AvatarFallback id={userId} nickname={userName} />
       )}
     </div>
   );
 }
-
-//TODO: 프로필 이미지가 없을 경우의 프로필 컴포넌트 구현 필요 (AvatarFallback)

--- a/src/components/common/AvatarFallback.tsx
+++ b/src/components/common/AvatarFallback.tsx
@@ -1,0 +1,25 @@
+import { cva } from 'class-variance-authority';
+import { getMonogram, getProfileColorForId } from '@/utils/avatar';
+
+const AvatarFallbackStyle = cva('flex items-center justify-center w-full h-full text-gray-0', {
+  variants: {
+    color: {
+      orange: 'bg-orange-500/80',
+      blue: 'bg-blue-500/80',
+      green: 'bg-green-500/80',
+      pink: 'bg-pink-500/80',
+      purple: 'bg-purple-500/80',
+    },
+  },
+});
+
+interface AvatarFallbackProps {
+  nickname: string;
+  id: number;
+}
+
+export default function AvatarFallback({ nickname, id }: AvatarFallbackProps) {
+  const color = getProfileColorForId(id);
+
+  return <div className={AvatarFallbackStyle({ color })}>{getMonogram(nickname)}</div>;
+}


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #41 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #41

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

- 프로필 이미지 url이 null일때 보여질 아바타 폴백 컴포넌트 구현하였습니다
- 아바타 컴포넌트에 연결도 해두었습니다!

### 적용된 모습
<img width="457" height="130" alt="image" src="https://github.com/user-attachments/assets/806f1b78-d14d-4e3a-8dee-4470500fd347" />


## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

- 수정사항 있으시면 말씀해주세요!
- 지금 고민되는 부분은 common 하위에 Avatar, AvatarFallback 컴포넌트가 있는데 하나의 폴더로 묶는게 좋을까요? ex) `common/avatar/Avatar` `common/avatar/AvatarFallback`

<img width="248" height="71" alt="image" src="https://github.com/user-attachments/assets/ca025ed9-5d7d-4a73-9835-9f5778726fe4" />


## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
