### PR TITLE
[✨ Feature] 페이지 이동 컴포넌트 구현

### DIFF
--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -1,11 +1,11 @@
 import type { ComponentPropsWithoutRef } from 'react';
 import { Link } from 'react-router';
-import { twMerge } from 'tailwind-merge';
 import Logos from '@/assets/logos';
+import { cn } from '@/utils/cn';
 
 type LogoProps = {
   size?: 'Large' | 'Medium' | 'Small'; //해당 prop을 활용하여 Logo의 크기를 지정할 수 있습니다.
-  color?: 'primary' | 'base'; // 해당 prop들은 색상 지정할 수 있습니다.
+  color?: 'primary' | 'base'; // 해당 prop들로 색상 지정할 수 있습니다.
   className?: string;
 } & ComponentPropsWithoutRef<'h1'>;
 
@@ -13,12 +13,11 @@ export function Logo({ size = 'Medium', color = 'primary', className, ...rest }:
   //default 값
   const LogoComponent = Logos[size];
 
-  const colorClass =
-    color === 'primary' ? 'text-[var(--color-primary)]' : 'text-[var(--color-base)]';
+  const colorClass = color === 'primary' ? 'text-primary' : 'text-base';
 
   return (
-    <h1 className={twMerge('inline-flex', className)} {...rest}>
-      <Link to='/' className={twMerge('inline-flex', colorClass)} aria-label='Taskify 홈으로 이동'>
+    <h1 className={cn('inline-flex', className)} {...rest}>
+      <Link to='/' className={cn('inline-flex', colorClass)} aria-label='Taskify 홈으로 이동'>
         <LogoComponent />
       </Link>
     </h1>


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!--  #52  -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->


- close #52 

## ✨ 작업한 내용
- PageNation 컴포넌트 구현
- prev, next props로 이전 / 다음 페이지의 URL을 전달받아 렌더링
- 호버시 바탕색과 svg의 색이 바뀌도록 설정
 <img width="87" height="60" alt="이동버튼" src="https://github.com/user-attachments/assets/a06b8525-69ec-49db-88b3-1de11367bd3a" />
<img width="86" height="61" alt="호버" src="https://github.com/user-attachments/assets/b7de09a1-a214-402f-a700-30c26d994802" />

## 💁 리뷰 요청 / 코멘트
단순히 prev/next URL만 받아서 이동하는 것이 아닌 페이지 배열을 받아서 내부에서 prev/next를 계산하는 형태로 하는 것이 좋을까요?
<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
