### PR TITLE
[✨ Feature/52] 페이지 이동 컴포넌트 구현

### DIFF
--- a/src/components/common/PageNation.tsx
+++ b/src/components/common/PageNation.tsx
@@ -5,7 +5,7 @@ const baseButtonStyle =
   'flex h-10 w-10 items-center justify-center border text-gray-300 transition-colors hover:border-gray-300 hover:bg-violet-500/10 hover:text-primary disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-gray-300 disabled:hover:bg-transparent';
 
 type NavigationButtonProps = {
-  onClick?: () => void;
+  onClick: () => void;
   direction: 'prev' | 'next';
   ariaLabel: string;
   disabled?: boolean;
@@ -28,7 +28,7 @@ export function NavigationButton({
     <button
       type='button'
       onClick={onClick}
-      disabled={disabled || !onClick}
+      disabled={disabled}
       className={cn(baseButtonStyle, borderRadiusClass)}
       aria-label={ariaLabel}>
       <Icon className='h-6 w-6' aria-hidden='true' />
@@ -37,25 +37,33 @@ export function NavigationButton({
 }
 
 type PageNationProps = {
-  onPrev?: () => void;
-  onNext?: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+  prevDisabled?: boolean;
+  nextDisabled?: boolean;
   className?: string;
 };
 
-export function PageNation({ onPrev, onNext, className }: PageNationProps) {
+export function PageNation({
+  onPrev,
+  onNext,
+  prevDisabled = false,
+  nextDisabled = false,
+  className,
+}: PageNationProps) {
   return (
     <div className={cn('mt-8 flex h-10 w-20 items-center justify-between', className)}>
       <NavigationButton
         onClick={onPrev}
         direction='prev'
         ariaLabel='이전 페이지'
-        disabled={!onPrev}
+        disabled={prevDisabled}
       />
       <NavigationButton
         onClick={onNext}
         direction='next'
         ariaLabel='다음 페이지'
-        disabled={!onNext}
+        disabled={nextDisabled}
       />
     </div>
   );


### PR DESCRIPTION
## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 변수/함수 이름 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

## 2. UI

- [x] UI 동작 및 레이아웃 확인

## 3. 컨벤션

- [x] 팀 컨벤션에 맞게 함수 이름을 정의했는지

## 🔗 이슈 번호

<!--  #52  -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->


- close #52 

## ✨ 작업한 내용
- PageNation 컴포넌트 구현
- prev, next props로 이전 / 다음 페이지의 URL을 전달받아 렌더링
- 호버시 바탕색과 svg의 색이 바뀌도록 설정
 <img width="87" height="60" alt="이동버튼" src="https://github.com/user-attachments/assets/a06b8525-69ec-49db-88b3-1de11367bd3a" />
<img width="86" height="61" alt="호버" src="https://github.com/user-attachments/assets/b7de09a1-a214-402f-a700-30c26d994802" />

## 💁 리뷰 요청 / 코멘트
단순히 prev/next URL만 받아서 이동하는 것이 아닌 페이지 배열을 받아서 내부에서 prev/next를 계산하는 형태로 하는 것이 좋을까요?


## 💡 참고사항


